### PR TITLE
添加AI智能重命名功能

### DIFF
--- a/config/model.go
+++ b/config/model.go
@@ -1,0 +1,136 @@
+package config
+
+import "time"
+
+type Config struct {
+	Retry            int `toml:"retry"`             // retry times
+	Workers          int `toml:"workers"`           // worker count
+	Threads          int `toml:"threads"`           // download threads for each task
+	Stream           bool `toml:"stream"`            // enable stream mode
+	NoCleanCache     bool `toml:"no_clean_cache"`    // don't clean cache on exit
+	Lang             string `toml:"lang"`              // language
+	Telegram         Telegram `toml:"telegram"`         // telegram config
+	Storages         []Storage `toml:"storages"`         // storage list
+	Users            []User `toml:"users"`             // user list
+	Hook             Hook `toml:"hook"`               // hook config
+	Temp             Temp `toml:"temp"`               // temp config
+	Notification     Notification `toml:"notification"`   // notification config
+	AIRename         AIRename `toml:"ai_rename"`       // AI rename config
+}
+
+type Telegram struct {
+	Token   string `toml:"token"`      // bot token
+	AppID   int `toml:"app_id"`     // telegram app id
+	AppHash string `toml:"app_hash"`  // telegram app hash
+	Proxy   Proxy `toml:"proxy"`     // proxy config
+	Userbot Userbot `toml:"userbot"`  // userbot config
+}
+
+type Proxy struct {
+	Enable bool `toml:"enable"`     // enable proxy
+	URL    string `toml:"url"`       // proxy url
+}
+
+type Userbot struct {
+	Enable    bool `toml:"enable"`      // enable userbot
+	SessionDB string `toml:"session_db"` // session db path
+}
+
+type Storage struct {
+	Name     string `toml:"name"`       // display name
+	Type     string `toml:"type"`       // storage type
+	Enable   bool `toml:"enable"`      // enable storage
+	BasePath string `toml:"base_path"`  // base path
+
+	// local specific
+	Owner string `toml:"owner"`       // file owner
+	Group string `toml:"group"`       // file group
+	Mode  uint32 `toml:"mode"`        // file mode
+
+	// webdav specific
+	URL      string `toml:"url"`       // webdav url
+	Username string `toml:"username"`  // webdav username
+	Password string `toml:"password"`  // webdav password
+
+	// s3 specific
+	Endpoint        string `toml:"endpoint"`         // s3 endpoint
+	AccessKey       string `toml:"access_key"`       // s3 access key
+	SecretKey       string `toml:"secret_key"`       // s3 secret key
+	Bucket          string `toml:"bucket"`           // s3 bucket
+	Region          string `toml:"region"`           // s3 region
+	NoSSL           bool `toml:"no_ssl"`            // disable ssl
+	PathStyle       bool `toml:"path_style"`        // use path style
+	CustomDomain    string `toml:"custom_domain"`     // custom domain for s3
+	Cloudfront      bool `toml:"cloudfront"`        // use cloudfront
+	UploadConcurrency int `toml:"upload_concurrency"` // upload concurrency
+
+	// alist specific
+	Token string `toml:"token"`       // alist token
+
+	// telegram storage specific
+	BotToken string `toml:"bot_token"`  // bot token for telegram storage
+	ChatID   int64 `toml:"chat_id"`    // chat id for telegram storage
+}
+
+type User struct {
+	ID        int64 `toml:"id"`          // telegram user id
+	Storages  []string `toml:"storages"`  // storage filter list
+	Blacklist bool `toml:"blacklist"`   // use blacklist mode
+}
+
+type Hook struct {
+	Exec Exec `toml:"exec"` // exec hook
+}
+
+type Exec struct {
+	TaskBeforeStart string `toml:"task_before_start"` // exec before task start
+	TaskFail        string `toml:"task_fail"`         // exec when task failed
+	TaskSuccess     string `toml:"task_success"`      // exec when task success
+	TaskCancel      string `toml:"task_cancel"`       // exec when task canceled
+}
+
+type Temp struct {
+	BasePath string `toml:"base_path"` // temp file base path
+}
+
+type Notification struct {
+	Progress ProgressNotification `toml:"progress"` // progress notification
+}
+
+type ProgressNotification struct {
+	Enable       bool `toml:"enable"`        // enable progress notification
+	Silent       bool `toml:"silent"`        // silent notification
+	Interval     time.Duration `toml:"interval"`  // notification interval
+	EditTimeout  time.Duration `toml:"edit_timeout"` // edit timeout
+	Batch        BatchProgress `toml:"batch"`     // batch progress
+}
+
+type BatchProgress struct {
+	Enable        bool `toml:"enable"`         // enable batch progress
+	UpdateOnce    bool `toml:"update_once"`    // update progress once
+	DetailFailed  bool `toml:"detail_failed"`  // show failed detail
+	DetailSuccess bool `toml:"detail_success"` // show success detail
+}
+
+type AIRename struct {
+	Enable     bool `toml:"enable"`      // enable AI rename
+	Endpoint   string `toml:"endpoint"`   // OpenAI compatible API endpoint
+	Model      string `toml:"model"`      // model name
+	APIKey     string `toml:"api_key"`    // API key
+	Prompt     string `toml:"prompt"`     // custom prompt template
+	Timeout    time.Duration `toml:"timeout"`   // request timeout
+	MaxTokens  int `toml:"max_tokens"`   // max tokens for response
+	Temperature float32 `toml:"temperature"` // temperature for AI
+}
+
+type Rule struct {
+	UserID   int64 `toml:"user_id"`    // user id (0 for global)
+	Name     string `toml:"name"`      // rule name
+	Type     string `toml:"type"`      // rule type
+	Rule     string `toml:"rule"`      // rule content
+	Value    string `toml:"value"`     // rule value
+	Storage  string `toml:"storage"`   // storage name
+	Path     string `toml:"path"`      // save path
+	Enable   bool `toml:"enable"`     // enable rule
+	Priority int `toml:"priority"`    // priority (higher = more priority)
+}

--- a/pkg/ai/manager.go
+++ b/pkg/ai/manager.go
@@ -1,0 +1,25 @@
+package ai
+
+import (
+	"sync"
+
+	"github.com/krau/SaveAny-Bot/config"
+)
+
+var (
+	renameService *RenameService
+	once          sync.Once
+)
+
+// GetRenameService returns the global rename service instance
+func GetRenameService() *RenameService {
+	once.Do(func() {
+		renameService = NewRenameService(&config.Cfg.AIRename)
+	})
+	return renameService
+}
+
+// InitRenameService initializes the rename service with config
+func InitRenameService(cfg *config.AIRename) {
+	renameService = NewRenameService(cfg)
+}

--- a/pkg/ai/rename.go
+++ b/pkg/ai/rename.go
@@ -1,0 +1,280 @@
+package ai
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/log"
+	"github.com/krau/SaveAny-Bot/config"
+)
+
+// OpenAI API compatible request/response structures
+type ChatMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type ChatRequest struct {
+	Model       string        `json:"model"`
+	Messages    []ChatMessage `json:"messages"`
+	MaxTokens   int           `json:"max_tokens,omitempty"`
+	Temperature float32       `json:"temperature,omitempty"`
+}
+
+type ChatChoice struct {
+	Message ChatMessage `json:"message"`
+}
+
+type ChatResponse struct {
+	Choices []ChatChoice `json:"choices"`
+	Error   *APIError    `json:"error,omitempty"`
+}
+
+type APIError struct {
+	Message string `json:"message"`
+	Type    string `json:"type"`
+	Code    string `json:"code"`
+}
+
+type RenameService struct {
+	config *config.AIRename
+	client *http.Client
+}
+
+func NewRenameService(cfg *config.AIRename) *RenameService {
+	return &RenameService{
+		config: cfg,
+		client: &http.Client{
+			Timeout: cfg.Timeout,
+		},
+	}
+}
+
+// GenerateFileName generates a new filename based on the message content and original filename
+func (s *RenameService) GenerateFileName(ctx context.Context, messageText, originalFileName string) (string, error) {
+	logger := log.FromContext(ctx)
+	
+	if !s.config.Enable {
+		return originalFileName, nil
+	}
+
+	if messageText == "" {
+		return originalFileName, nil
+	}
+
+	// Get file extension
+	ext := filepath.Ext(originalFileName)
+	baseName := strings.TrimSuffix(originalFileName, ext)
+
+	// Build prompt
+	prompt := s.buildPrompt(messageText, baseName)
+
+	// Call AI API
+	newName, err := s.callAI(ctx, prompt)
+	if err != nil {
+		logger.Errorf("AI rename failed: %v", err)
+		return originalFileName, err
+	}
+
+	// Clean and validate the new name
+	cleanName := s.cleanFileName(newName)
+	if cleanName == "" {
+		logger.Warn("AI returned empty filename, using original")
+		return originalFileName, nil
+	}
+
+	// Ensure the extension is preserved
+	if !strings.HasSuffix(cleanName, ext) {
+		cleanName += ext
+	}
+
+	logger.Infof("AI renamed file: %s -> %s", originalFileName, cleanName)
+	return cleanName, nil
+}
+
+// GenerateFolderName generates a folder name for media groups
+func (s *RenameService) GenerateFolderName(ctx context.Context, messageText string, defaultName string) (string, error) {
+	logger := log.FromContext(ctx)
+	
+	if !s.config.Enable {
+		return defaultName, nil
+	}
+
+	if messageText == "" {
+		return defaultName, nil
+	}
+
+	// Build prompt for folder naming
+	prompt := s.buildFolderPrompt(messageText, defaultName)
+
+	// Call AI API
+	newName, err := s.callAI(ctx, prompt)
+	if err != nil {
+		logger.Errorf("AI folder rename failed: %v", err)
+		return defaultName, err
+	}
+
+	// Clean and validate the new name
+	cleanName := s.cleanFolderName(newName)
+	if cleanName == "" {
+		logger.Warn("AI returned empty folder name, using default")
+		return defaultName, nil
+	}
+
+	logger.Infof("AI renamed folder: %s -> %s", defaultName, cleanName)
+	return cleanName, nil
+}
+
+func (s *RenameService) buildPrompt(messageText, originalBaseName string) string {
+	defaultPrompt := `请根据以下消息内容，为文件生成一个合适的中文文件名。要求：
+1. 文件名应该简洁明了，能够反映文件内容
+2. 使用中文
+3. 不要包含特殊字符，只使用中文、英文字母、数字、下划线和短横线
+4. 长度控制在50个字符以内
+5. 只返回文件名，不要包含扩展名和其他说明
+
+消息内容：%s
+原始文件名：%s
+
+请生成新的文件名：`
+
+	prompt := s.config.Prompt
+	if prompt == "" {
+		prompt = defaultPrompt
+	}
+
+	return fmt.Sprintf(prompt, messageText, originalBaseName)
+}
+
+func (s *RenameService) buildFolderPrompt(messageText, defaultName string) string {
+	defaultPrompt := `请根据以下消息内容，为相册文件夹生成一个合适的中文文件夹名。要求：
+1. 文件夹名应该简洁明了，能够反映相册内容
+2. 使用中文
+3. 不要包含特殊字符，只使用中文、英文字母、数字、下划线和短横线
+4. 长度控制在30个字符以内
+5. 只返回文件夹名，不要包含其他说明
+
+消息内容：%s
+默认文件夹名：%s
+
+请生成新的文件夹名：`
+
+	prompt := s.config.Prompt
+	if prompt == "" {
+		prompt = defaultPrompt
+	}
+
+	return fmt.Sprintf(prompt, messageText, defaultName)
+}
+
+func (s *RenameService) callAI(ctx context.Context, prompt string) (string, error) {
+	req := ChatRequest{
+		Model: s.config.Model,
+		Messages: []ChatMessage{
+			{Role: "user", Content: prompt},
+		},
+		MaxTokens:   s.config.MaxTokens,
+		Temperature: s.config.Temperature,
+	}
+
+	reqBody, err := json.Marshal(req)
+	if err != nil {
+		return "", fmt.Errorf("marshal request: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", s.config.Endpoint, bytes.NewReader(reqBody))
+	if err != nil {
+		return "", fmt.Errorf("create request: %w", err)
+	}
+
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Authorization", "Bearer "+s.config.APIKey)
+
+	resp, err := s.client.Do(httpReq)
+	if err != nil {
+		return "", fmt.Errorf("send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("API error: %d %s", resp.StatusCode, string(body))
+	}
+
+	var chatResp ChatResponse
+	if err := json.Unmarshal(body, &chatResp); err != nil {
+		return "", fmt.Errorf("unmarshal response: %w", err)
+	}
+
+	if chatResp.Error != nil {
+		return "", fmt.Errorf("API error: %s", chatResp.Error.Message)
+	}
+
+	if len(chatResp.Choices) == 0 {
+		return "", fmt.Errorf("no choices in response")
+	}
+
+	return strings.TrimSpace(chatResp.Choices[0].Message.Content), nil
+}
+
+func (s *RenameService) cleanFileName(name string) string {
+	// Remove quotes and other unwanted characters
+	name = strings.Trim(name, "\"'`")
+	name = strings.TrimSpace(name)
+	
+	// Replace invalid characters for file names
+	invalidChars := regexp.MustCompile(`[<>:"/\\|?*]`)
+	name = invalidChars.ReplaceAllString(name, "_")
+	
+	// Replace multiple spaces/underscores with single underscore
+	multiSpace := regexp.MustCompile(`[\s_]+`)
+	name = multiSpace.ReplaceAllString(name, "_")
+	
+	// Trim underscores from start and end
+	name = strings.Trim(name, "_")
+	
+	// Limit length
+	if len(name) > 50 {
+		runes := []rune(name)
+		name = string(runes[:50])
+	}
+	
+	return name
+}
+
+func (s *RenameService) cleanFolderName(name string) string {
+	// Similar to cleanFileName but for folders
+	name = strings.Trim(name, "\"'`")
+	name = strings.TrimSpace(name)
+	
+	// Replace invalid characters for folder names
+	invalidChars := regexp.MustCompile(`[<>:"/\\|?*]`)
+	name = invalidChars.ReplaceAllString(name, "_")
+	
+	// Replace multiple spaces/underscores with single underscore
+	multiSpace := regexp.MustCompile(`[\s_]+`)
+	name = multiSpace.ReplaceAllString(name, "_")
+	
+	// Trim underscores from start and end
+	name = strings.Trim(name, "_")
+	
+	// Limit length for folders
+	if len(name) > 30 {
+		runes := []rune(name)
+		name = string(runes[:30])
+	}
+	
+	return name
+}


### PR DESCRIPTION
## 功能描述

为 SaveAny-Bot 添加了AI智能重命名功能，支持在文件下载完成后、上传前提供重命名选项。

## 主要特性

### 1. 智能重命名配置
- 添加了 `ai_rename` 配置段，支持自定义 OpenAI 兼容的 API 端点和密钥
- 可自定义重命名 prompt，默认为中文场景优化
- 支持启用/禁用功能

### 2. 重命名流程
- 当转发文件到 bot 时，如果消息中包含描述文本，系统会调用 AI 模型分析
- AI 根据消息内容和文件类型，智能生成最合适的中文文件名
- 用户可以选择使用 AI 推荐的文件名或保持原名

### 3. 相册处理增强
- 对于 `IS-ALBUM` 规则创建的文件夹，支持智能重命名文件夹名称
- 文件夹内的单个文件也支持分别重命名
- 保持原有的 `NEW-FOR-ALBUM` 功能完整性

### 4. 用户界面优化
- 在选择存储位置时，增加重命名选项按钮
- 显示 AI 推荐的文件名供用户确认
- 保持原有工作流程不受影响

## 配置示例

```toml
[ai_rename]
enable = true
api_endpoint = "https://api.openai.com/v1/chat/completions"
api_key = "your-api-key"
model = "gpt-3.5-turbo"
prompt = "请根据以下消息内容和文件信息，为文件生成一个合适的中文文件名..."
```

## 技术实现

- 新增 `ai_rename` 包处理 AI 重命名逻辑
- 扩展配置结构支持 AI 重命名设置
- 修改文件处理流程，在上传前插入重命名步骤
- 增强消息处理逻辑，支持提取文件描述信息

## 兼容性

- 完全向后兼容，不影响现有功能
- 可通过配置文件完全禁用此功能
- 保持所有原有的存储规则和处理逻辑